### PR TITLE
Removing most places where environment is in name

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -21,19 +21,19 @@ resource "aws_cloudwatch_log_group" "cluster" {
 ALB for cluster
 ======*/
 resource "aws_alb" "cluster_alb" {
-  name            = "${var.environment}-${var.cluster_name}-alb"
+  name            = "${var.cluster_name}-alb"
   subnets         = ["${split(",", var.public_subnets)}"]
   security_groups = ["${aws_security_group.cluster_alb_sg.id}"]
 
   tags {
-    Name        = "${var.environment}-${var.cluster_name}-alb"
+    Name        = "${var.cluster_name}-alb"
     Environment = "${var.environment}"
   }
 }
 
 /* security group for ALB */
 resource "aws_security_group" "cluster_alb_sg" {
-  name        = "${var.environment}-${var.cluster_name}-alb-sg"
+  name        = "${var.cluster_name}-alb-sg"
   description = "Allow HTTP/HTTPS from Anywhere into ALB"
   vpc_id      = "${var.vpc_id}"
 
@@ -59,7 +59,7 @@ resource "aws_security_group" "cluster_alb_sg" {
   }
 
   tags {
-    Name = "${var.environment}-${var.cluster_name}-alb-sg"
+    Name = "${var.cluster_name}-alb-sg"
   }
 }
 
@@ -69,7 +69,7 @@ resource "random_id" "target_group" {
 
 /* default target group and listeners */
 resource "aws_alb_target_group" "cluster_alb_default_tg" {
-  name                  = "${var.environment}-${var.cluster_name}-alb-${random_id.target_group.hex}"
+  name                  = "${var.cluster_name}-alb-${random_id.target_group.hex}"
   port                  = 80
   protocol              = "HTTP"
   vpc_id                = "${var.vpc_id}"

--- a/service/main.tf
+++ b/service/main.tf
@@ -17,7 +17,7 @@ resource "aws_route53_record" "service" {
 IAM task role
 ======*/
 resource "aws_iam_role" "ecs_task_role" {
-  name = "${var.service_name}-${var.environment}-ecs-task-role"
+  name = "${var.service_name}-ecs-task-role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -61,7 +61,7 @@ resource "random_id" "target_group" {
 }
 
 resource "aws_alb_target_group" "service" {
-  name        = "${var.service_name}-${var.environment}-alb-tg-${random_id.target_group.hex}"
+  name        = "${var.service_name}-alb-tg-${random_id.target_group.hex}"
   port        = "${var.port}"
   protocol    = "HTTPS"
   vpc_id      = "${var.vpc_id}"
@@ -137,7 +137,7 @@ Security Group
 ======*/
 resource "aws_security_group" "ecs_service" {
   vpc_id      = "${var.vpc_id}"
-  name        = "${var.service_name}-${var.environment}-ecs-service-sg"
+  name        = "${var.service_name}-ecs-service-sg"
   description = "Allow egress from container"
 
   egress {
@@ -155,7 +155,7 @@ resource "aws_security_group" "ecs_service" {
   }
 
   tags {
-    Name        = "${var.service_name}-${var.environment}-ecs-service-sg"
+    Name        = "${var.service_name}-ecs-service-sg"
     Environment = "${var.environment}"
   }
 }


### PR DESCRIPTION
Since our resources are in different OUs based on environment, this
is mostly redundant and affecting 32-character limits on some names.
The environment is currently left in usernames and cloudwatch names,
because it might help clarity there.