### PR TITLE
Make alb cidr block a variable for ecs cluster

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "ingress" {
 
   type        = "ingress"
   protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = "${var.alb_cidr}"
   from_port   = "${element(var.open_ports, count.index)}"
   to_port     = "${element(var.open_ports, count.index)}"
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -22,3 +22,8 @@ variable "public_subnets" {
 variable "hosted_zone_name" {
   description = "Route53 hosted zone name to use for creating an ALB cert"
 }
+
+variable "alb_cidr" {
+  type = "list"
+  default = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
In the RIALTO project, we currently require users to be coming through the full VPN in order to access the web host. This change adds a cidr block variable to the ALB security group (defaulted to 0.0.0.0/0) that can be set by the calling terraform plan.