### PR TITLE
Change cloudwatch alarm metrics to look for LB name vs arn

### DIFF
--- a/service/cloudwatch.tf
+++ b/service/cloudwatch.tf
@@ -21,9 +21,9 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_high_alert" {
 }
 
 # Get the data for the given HTTP and HTTPS listeners.
-data "aws_lb" "service" {
-  name = "${var.cluster_name}-alb"
-}
+#data "aws_lb" "service" {
+#  name = "${var.cluster_name}-alb"
+#}
 
 resource "aws_cloudwatch_metric_alarm" "elb_response" {
   alarm_name          = "${var.service_name}-${var.environment}-elb-response-slow"
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_metric_alarm" "elb_response" {
   treat_missing_data  = "notBreaching"
 
   dimensions {
-    LoadBalancer = "${data.aws_lb.service.arn_suffix}"
+    LoadBalancer = "${var.cluster_alb_dns_name}"
     TargetGroup  = "${aws_alb_target_group.service.arn_suffix}"
   }
 
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_metric_alarm" "elb_health_hosts" {
   threshold           = "1"
 
   dimensions {
-    LoadBalancer = "${data.aws_lb.service.arn_suffix}"
+    LoadBalancer = "${var.cluster_alb_dns_name}"
     TargetGroup  = "${aws_alb_target_group.service.arn_suffix}"
   }
 


### PR DESCRIPTION
I think this works to solve issue #9 .  Tested on a fresh cluster/service build and did not receive any errors.