### PR TITLE
Make hostnames more configurable for siniopia

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -112,7 +112,7 @@ data "aws_route53_zone" "selected" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  domain_name       = "${var.cluster_name}-lb.${var.hosted_zone_name}"
+  domain_name       = "${var.certificate_name}"
   validation_method = "DNS"
 }
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -23,6 +23,11 @@ variable "hosted_zone_name" {
   description = "Route53 hosted zone name to use for creating an ALB cert"
 }
 
+variable "certificate_name" {
+  description = "Hostname for the certificate to use for validation"
+  default     = "${var.cluster_name}-lb.${var.hosted_zone_name}"
+}
+
 variable "alb_cidr" {
   type = "list"
   default = ["0.0.0.0/0"]

--- a/service/main.tf
+++ b/service/main.tf
@@ -3,7 +3,7 @@ Route53 record
 ======*/
 resource "aws_route53_record" "service" {
   zone_id = "${var.cluster_zone_id}"
-  name    = "${var.service_host}.${var.cluster_zone_name}"
+  name    = "${var.service_host}"
   type    = "A"
 
   alias {

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -11,8 +11,7 @@ variable "environment" {
 }
 
 variable "service_host" {
-  description = "Hostname for the ALB (ie: 'consul.stanford.edu')"
-  default     = "${var.service_name}.${var.cluster_zone_name}"
+  description = "Hostname for the ALB, default should be $service_name.$cluster_zone_name (ie: 'consul.stanford.edu')"
 }
 
 #######################################################################

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -11,7 +11,8 @@ variable "environment" {
 }
 
 variable "service_host" {
-  description = "Shorthost for the ALB hostname (ie: 'consul' for consul.sul.stanford.edu)"
+  description = "Hostname for the ALB (ie: 'consul.stanford.edu')"
+  default     = "${var.service_name}.${var.cluster_zone_name}"
 }
 
 #######################################################################


### PR DESCRIPTION
sinipia.io wants to be the main responder for the cluster, so make
the hostnames used for certs and services allow something more flexible
than service.zone.