### PR TITLE
Rsmith11host

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -112,7 +112,7 @@ data "aws_route53_zone" "selected" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  domain_name       = "${var.cluster_name}-lb.${var.hosted_zone_name}"
+  domain_name       = "${var.certificate_name}"
   validation_method = "DNS"
 }
 

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -105,6 +105,10 @@ resource "aws_alb_listener" "cluster_alb_https_listener" {
   }
 }
 
+locals {
+  default_certificate_name = "${var.cluster_name}-lb.${var.hosted_zone_name}"
+  certificate_name         = "${var.certificate_name != "" ? var.certificate_name : local.default_certificate_name}"
+}
 /* cert for https listener */
 data "aws_route53_zone" "selected" {
   name         = "${var.hosted_zone_name}."
@@ -112,7 +116,7 @@ data "aws_route53_zone" "selected" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  domain_name       = "${var.certificate_name}"
+  domain_name       = "${local.certificate_name}"
   validation_method = "DNS"
 }
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -25,7 +25,7 @@ variable "hosted_zone_name" {
 
 variable "certificate_name" {
   description = "Hostname for the certificate to use for validation"
-  default     = "${var.cluster_name}-lb.${var.hosted_zone_name}"
+  default = ""
 }
 
 variable "alb_cidr" {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -23,6 +23,11 @@ variable "hosted_zone_name" {
   description = "Route53 hosted zone name to use for creating an ALB cert"
 }
 
+variable "certificate_name" {
+  description = "Hostname for the certificate to use for validation"
+  default     = "${var.cluster_name}-lb.${var.hosted_zone_name}"
+}
+
 variable "alb_cidr" {
   type = "list"
   default = ["0.0.0.0/0"]

--- a/service/main.tf
+++ b/service/main.tf
@@ -3,7 +3,7 @@ Route53 record
 ======*/
 resource "aws_route53_record" "service" {
   zone_id = "${var.cluster_zone_id}"
-  name    = "${var.service_host}.${var.cluster_zone_name}"
+  name    = "${var.service_host}"
   type    = "A"
 
   alias {

--- a/service/main.tf
+++ b/service/main.tf
@@ -1,9 +1,15 @@
 /*====
 Route53 record
 ======*/
+
+locals {
+  default_service_host = "${var.service_name}.${var.cluster_zone_name}"
+  service_host         = "${var.service_fullhost != "" ? var.service_fullhost : local.default_service_host}"
+}
+
 resource "aws_route53_record" "service" {
   zone_id = "${var.cluster_zone_id}"
-  name    = "${var.service_host}"
+  name    = "${local.service_host}"
   type    = "A"
 
   alias {

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -11,7 +11,8 @@ variable "environment" {
 }
 
 variable "service_host" {
-  description = "Shorthost for the ALB hostname (ie: 'consul' for consul.sul.stanford.edu)"
+  description = "Hostname for the ALB (ie: 'consul.stanford.edu')"
+  default     = "${var.service_name}.${var.cluster_zone_name}"
 }
 
 #######################################################################

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -11,8 +11,12 @@ variable "environment" {
 }
 
 variable "service_host" {
+  description = "Shorthost for the ALB hostname (ie: 'consul' for consul.sul.stanford.edu)"
+}
+
+variable "service_fullhost" {
   description = "Hostname for the ALB (ie: 'consul.stanford.edu')"
-  default     = "${var.service_name}.${var.cluster_zone_name}"
+  default = ""
 }
 
 #######################################################################


### PR DESCRIPTION
We needed to find a way to set hostnames for non-stanford.edu domains.  This commit makes it possible to set the var.certificate_name variable in the cluster call to the domain name you want, and the var.service_fullhost variable in the service call to the full URL, including the application name.  If you don't call those, then it uses local variables to check, and if null it sets sane defaults.