### PR TITLE
Adds the service type as a variable, default is FARGATE

### DIFF
--- a/service/main.tf
+++ b/service/main.tf
@@ -47,7 +47,7 @@ ECS task definitions
 resource "aws_ecs_task_definition" "service" {
   family                   = "${var.service_name}"
   container_definitions    = "${var.container_definition}"
-  requires_compatibilities = ["FARGATE"]
+  requires_compatibilities = ["${var.service_type}"]
   network_mode             = "awsvpc"
   task_role_arn            = "${aws_iam_role.ecs_task_role.arn}"
   execution_role_arn       = "${var.execution_role_arn}"
@@ -170,7 +170,7 @@ resource "aws_ecs_service" "service" {
   name            = "${var.service_name}"
   task_definition = "${aws_ecs_task_definition.service.arn}"
   desired_count   = "${var.min_capacity}"
-  launch_type     = "FARGATE"
+  launch_type     = "${var.service_type}"
   cluster         = "${var.cluster_id}"
 
   network_configuration {

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -110,3 +110,8 @@ variable "execution_role_arn" {
 variable "cloudwatch_alerts_arn" {
   description = "SNS topic to send cloudwatch alerts to"
 }
+
+variable "service_type" {
+    default = "FARGATE"
+    description = "TYPE and COMPATIBILITY for container service, default [FARGATE]."
+}


### PR DESCRIPTION
This adds a variable (default == FARGATE) to set the service type, allowing this module to be used for EC2 compatible services in the future.